### PR TITLE
Adjusted code for RI26 to be missing if there was no valid repsonse r…

### DIFF
--- a/Step03 - MICS to VCQI Conversion Steps.do
+++ b/Step03 - MICS to VCQI Conversion Steps.do
@@ -577,7 +577,7 @@ if $RI_SURVEY==1 {
 		replace RI26=99 if RI26==8
 		
 		* Replace all other values with missing
-		replace RI26=2 if !inlist(RI26,1,2,99)
+		replace RI26=. if !inlist(RI26,1,2,99)
 	}
 	else if ${MICS_NUM}==3 {
 		gen RI26=.
@@ -593,7 +593,7 @@ if $RI_SURVEY==1 {
 		replace RI26=99 if ${CARD_SEEN}==8
 		
 		* Replace all other values to missing
-		replace RI26=2 if !inlist(${CARD_SEEN},1,2,99)
+		replace RI26=. if !inlist(RI26,1,2,99)
 		
 	}
 	


### PR DESCRIPTION
…ather than default to no...Also adjusted replace code to look at RI26 rather than  variable