### PR TITLE
Proper levelnames remove dob 

### DIFF
--- a/MICS to VCQI - levels of datasets.do
+++ b/MICS to VCQI - levels of datasets.do
@@ -18,6 +18,7 @@ Stata version:    14.0
 *				version
 * Date 			number 	Name			What Changed
 * 2019-02-06	1.02	MK Trimner		Made the names proper case
+* 2019-07-24	1.03	MK Trimner		Removed extra level2name so decode works
 *******************************************************************************
 * Bring in Combined dataset
 use "${OUTPUT_FOLDER}/MICS_${MICS_NUM}_combined_dataset", clear
@@ -39,7 +40,6 @@ bysort $PROVINCE_ID: keep if _n == 1
 keep $PROVINCE_ID
 sort $PROVINCE_ID
 rename $PROVINCE_ID level2id
-gen level2name = ""
 decode level2id, generate(level2name)
 replace level2name = proper(level2name)
 label value level2id

--- a/MICS to VCQI - levels of datasets.do
+++ b/MICS to VCQI - levels of datasets.do
@@ -12,6 +12,13 @@ Author:         Mary Kay Trimner
 
 Stata version:    14.0
 **********************************************************************/
+
+* Change log
+* 				Updated
+*				version
+* Date 			number 	Name			What Changed
+* 2019-02-06	1.02	MK Trimner		Made the names proper case
+*******************************************************************************
 * Bring in Combined dataset
 use "${OUTPUT_FOLDER}/MICS_${MICS_NUM}_combined_dataset", clear
 
@@ -23,6 +30,7 @@ clear
 set obs 1
 generate level1id = 1 in 1
 generate level1name = "${LEVEL1_NAME}" in 1
+replace level1name = proper(level1name)
 save level1name, replace
 
 * Create level2names dataset
@@ -33,6 +41,7 @@ sort $PROVINCE_ID
 rename $PROVINCE_ID level2id
 gen level2name = ""
 decode level2id, generate(level2name)
+replace level2name = proper(level2name)
 label value level2id
 save level2names, replace
 
@@ -54,6 +63,7 @@ if wordcount("$LEVEL_3_ID") > 1 {
 	forvalue i = 1/`=_N' {
 		replace level3name="`:label l3id `=level3id[`i']''" in `i'
 	}
+	replace level3name = proper(level3name)	
 	bysort level3id: keep if _n==1
 	sort level3id
 	keep level3*
@@ -66,8 +76,8 @@ else {
 	keep $LEVEL_3_ID 
 	sort $LEVEL_3_ID
 	rename $LEVEL_3_ID level3id
-	gen level3name = ""
 	decode level3id, generate(level3name)
+	replace level3name = proper(level3name)	
 	label value level3id 
 	save level3names, replace
 }

--- a/Step03 - MICS to VCQI Conversion Steps.do
+++ b/Step03 - MICS to VCQI Conversion Steps.do
@@ -14,6 +14,7 @@ Stata version:    14.0
 *				version
 * Date 			number 	Name			What Changed
 * 2019-02-06	1.02	MK Trimner		Removed history dob from card if not provided
+* 2019-12-05	1.03	MK Trimner		Made HH_ID and Cluster name a string
 *******************************************************************************
 
 use "${OUTPUT_FOLDER}/MICS_${MICS_NUM}_combined_dataset", clear
@@ -214,7 +215,7 @@ save, replace
 			}
 			else if missing(vallab) {
 				use "${OUTPUT_FOLDER}/MICS_${MICS_NUM}_combined_dataset", clear
-				gen HH04=HH03
+				tostring HH03, gen(HH04) //gen HH04=HH03
 				save, replace
 			}
 	}
@@ -230,7 +231,7 @@ label value HH03
 
 ****************************************************************
 * Create variable for HH14 household number
-clonevar HH14=$HH_ID
+tostring $HH_ID, gen(HH14) //clonevar HH14=$HH_ID
 
 ****************************************************************
 * Create VCQI Variable HH12
@@ -371,7 +372,7 @@ clonevar HM01=HH01
 clonevar HM02=HH02
 clonevar HM03=HH03
 clonevar HM04=HH04
-clonevar HM09=${HH_ID}
+tostring $HH_ID, gen(HM09) //clonevar HM09=${HH_ID}
 clonevar HM22=${HM_LINE}
 
 * Create variables for HM27(sex), HM29(age years) and HM30(age months) 

--- a/Step03 - MICS to VCQI Conversion Steps.do
+++ b/Step03 - MICS to VCQI Conversion Steps.do
@@ -7,6 +7,14 @@ Date Created:    			2016-04-28
 Author:         Mary Kay Trimner
 Stata version:    14.0
 ********************************************************************************/
+**********************************************************************/
+
+* Change log
+* 				Updated
+*				version
+* Date 			number 	Name			What Changed
+* 2019-02-06	1.02	MK Trimner		Removed history dob from card if not provided
+*******************************************************************************
 
 use "${OUTPUT_FOLDER}/MICS_${MICS_NUM}_combined_dataset", clear
 
@@ -676,12 +684,6 @@ if $RI_SURVEY==1 {
 				replace dob_date_`v'_`d'=. if inlist(dob_date_`v'_`d',44,4444,66,6666)
 			}
 		}
-	}
-
-	* If no card dob data provided, replace with history dob information 
-	foreach d in m d y {
-		replace dob_date_card_`d'=dob_date_history_`d' if missing(dob_date_card_`d') & !missing(dob_date_history_`d')
-		
 	}
 
 	* Create all card and register variables


### PR DESCRIPTION
Made level dataset names proper case... removed code to populate card dob with history dob if missing card date. Made HHid and clustername strings.